### PR TITLE
Handle exception of network errors

### DIFF
--- a/lib/Cleantalk.php
+++ b/lib/Cleantalk.php
@@ -444,10 +444,7 @@ class Cleantalk {
 
                 return false;
 				
-            } else {
-				
-				$servers = $this->get_servers_ip($url_host);
-				
+            } else if(null !== $servers = $this->get_servers_ip($url_host)) {
                 // Loop until find work server
                 foreach ($servers as $server) {
                     
@@ -461,6 +458,8 @@ class Cleantalk {
                         break;
                     }
                 }
+            } else {
+                throw TransportException::fromUrlHostError($url_host);
             }
         }
 		

--- a/lib/TransportException.php
+++ b/lib/TransportException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Cleantalk;
+
+use Exception;
+
+class TransportException extends Exception
+{
+    /**
+     * @param string $url
+     * @return self
+     */
+    public static function fromUrlHostError($url_host)
+    {
+        return new self("Couldn't resolve host name for \"$url_host\".\nCheck your network connectivity.");
+    }
+}


### PR DESCRIPTION
When I'm not connected to internet and I try to test my code with PHPUnit, I got this error:

`Invalid argument supplied for foreach() ... cleantalk/php-antispam/lib/Cleantalk.php:450`

https://github.com/CleanTalk/php-antispam/blob/2515e2839ec1d1fc8c04c0855797eca30f4990a8/lib/Cleantalk.php#L448-L453

https://github.com/CleanTalk/php-antispam/blob/2515e2839ec1d1fc8c04c0855797eca30f4990a8/lib/Cleantalk.php#L488-L495

The error is not handle, so this PR fix that issue
