### PR TITLE
Respect all_headers from CleantalkRequest

### DIFF
--- a/lib/Cleantalk.php
+++ b/lib/Cleantalk.php
@@ -384,8 +384,8 @@ class Cleantalk {
      */
     private function httpRequest($msg) {
 		
-		// Wiping cleantalk's headers but, not for send_feedback
-		if($msg->method_name != 'send_feedback'){
+		// Wiping cleantalk's headers, but not for send_feedback and not for set headers
+		if($msg->method_name != 'send_feedback' && empty($msg->all_headers)){
 			
 			$ct_tmp = apache_request_headers();
 			


### PR DESCRIPTION
Before, if I set $ct_request->all_headers = $some_headers;
all_headers will be overridden anyway on $ct->isAllowMessage($ct_request) call.
This commit fix that issue.
If $ct_request->all_headers were set, it will be sent to CleanTalk server.
If all_headers is not set, it will set it same way as before and it will be sent to CleanTalk server.