### PR TITLE
API response documentation formatting, spelling, and clarity

### DIFF
--- a/examples/api_response_description.md
+++ b/examples/api_response_description.md
@@ -1,8 +1,11 @@
 ## API Response description
 API returns (`$api_result`) PHP object:
-  * allow (0|1) - allow to publish or not, in other words spam or ham
-  * comment (string) - server comment for requests.
-  * id (string MD5 HEX hash) - unique request idenifier.
-  * errno (int) - error number. errno == 0 if requests successfull.
-  * errstr (string) - comment for error issue, errstr == null if requests successfull.
-  * account_status - 0 account disabled, 1 account enabled, -1 unknown status.
+  * allow (`bool/0|1`) – allow result to be published or not, in other words, spam(`0`) or ham(`1`).
+  * comment (`string`) – server comment for requests.
+  * id (`MD5 hash hex string`) – unique MD5 hash used as request identifier.
+  * errno (`int`) - error number or `0` if the request is successful.
+  * errstr (`string | null`) – comment for error issue or `null` if the request is successful.
+  * account_status (`int`) – Status of the account:
+    * `0` account disabled
+    * `1` account enabled, 
+    * `-1` unknown status.


### PR DESCRIPTION
Modified the response description documentation for spelling and clarity.

I noticed `successful` was misspelled which then sent me down a rabbit hole to revisit the formatting a bit :D 