### PR TITLE
Fix. Verdict. Normalize allow to integer.

### DIFF
--- a/examples/api_response_description.md
+++ b/examples/api_response_description.md
@@ -1,6 +1,6 @@
 ## API Response description
 API returns (`$api_result`) PHP object:
-  * allow (`bool/0|1`) – allow result to be published or not, in other words, spam(`0`) or ham(`1`).
+  * allow (`int: 0|1`) – allow result to be published or not, in other words, spam(`0`) or ham(`1`).
   * comment (`string`) – server comment for requests.
   * id (`MD5 hash hex string`) – unique MD5 hash used as request identifier.
   * errno (`int`) - error number or `0` if the request is successful.

--- a/lib/CleantalkAntispam.php
+++ b/lib/CleantalkAntispam.php
@@ -276,7 +276,7 @@ class CleantalkAntispam
             $this->checkAccessKey();
         } catch (\Exception $e) {
             $this->verdict->error = $e->getMessage();
-            $this->verdict->allow = true;
+            $this->verdict->allow = 1;
         }
 
         try {
@@ -284,10 +284,10 @@ class CleantalkAntispam
         } catch (\Exception $e) {
             if ($this->block_no_js_visitor) {
                 $this->verdict->error = $e->getMessage();
-                $this->verdict->allow = false;
+                $this->verdict->allow = 0;
                 $this->verdict->comment = 'Please, enable JavaScript to process the form.';
             } else {
-                $this->verdict->allow = true;
+                $this->verdict->allow = 1;
             }
         }
     }
@@ -335,6 +335,7 @@ class CleantalkAntispam
      */
     private function beforeReturnVerdict()
     {
+        $this->verdict->allow = (int) (bool) $this->verdict->allow;
         $this->setImprovementSuggestions();
         return $this->verdict;
     }

--- a/lib/CleantalkVerdict.php
+++ b/lib/CleantalkVerdict.php
@@ -4,7 +4,12 @@ namespace CleanTalk;
 
 class CleantalkVerdict
 {
-    public $allow = true;
+    /**
+     * Whether the request is allowed, 1|0.
+     *
+     * @var int
+     */
+    public $allow = 1;
     public $comment = '';
     public $error = '';
     public $request_link = null;

--- a/lib/HTTP/CleantalkResponse.php
+++ b/lib/HTTP/CleantalkResponse.php
@@ -146,7 +146,7 @@ class CleantalkResponse
         $this->stop_words     = isset($obj->stop_words) ? Helper::fromUTF8($obj->stop_words, 'ISO-8859-1') : null;
         $this->comment        = isset($obj->comment) ? strip_tags(Helper::fromUTF8($obj->comment, 'ISO-8859-1'), '<p><a><br>') : null;
         $this->blacklisted    = isset($obj->blacklisted) ? $obj->blacklisted : null;
-        $this->allow          = isset($obj->allow) ? $obj->allow : 1;
+        $this->allow          = isset($obj->allow) ? (int) (bool) $obj->allow : 1;
         $this->id             = isset($obj->id) ? $obj->id : null;
         $this->fast_submit    = isset($obj->fast_submit) ? $obj->fast_submit : 0;
         $this->spam           = isset($obj->spam) ? $obj->spam : 0;


### PR DESCRIPTION
Ensures that the `allow` verdict always returns an integer (`1` or `0`) instead of mixed integer and boolean values. Also updates the API response documentation.